### PR TITLE
Fix code scanning alert no. 1: Implicit narrowing conversion in compound assignment

### DIFF
--- a/DesignPatterns/src/main/java/refactula/design/patterns/creational/object_pool/mutable/fibonacci/LargeNumber.java
+++ b/DesignPatterns/src/main/java/refactula/design/patterns/creational/object_pool/mutable/fibonacci/LargeNumber.java
@@ -33,7 +33,7 @@ public class LargeNumber {
     }
 
     public void sum(LargeNumber x, LargeNumber y) {
-        byte reminder = 0;
+        int reminder = 0;
         setZero();
         while (usedDigits < x.getDigitsAmount() || usedDigits < y.getDigitsAmount() || reminder > 0) {
             reminder += x.getDigit(usedDigits) + y.getDigit(usedDigits);


### PR DESCRIPTION
Fixes [https://github.com/Gio687351/testmililoncode/security/code-scanning/1](https://github.com/Gio687351/testmililoncode/security/code-scanning/1)

To fix the problem, we need to ensure that the type of the left-hand side of the compound assignment statement is at least as wide as the type of the right-hand side. In this case, we should change the type of `reminder` from `byte` to `int`. This will prevent any implicit narrowing conversion and ensure that the addition operation does not result in overflow or data loss.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
